### PR TITLE
Incoming blacklisted connections hotfix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # JCL Variables:
 jclArtifactName=jcl
 jclGroup=io.bitcoinsv.jcl
-jclVersion=2.3.0
+jclVersion=2.3.1
 
 # BitcoinJ dependency:
 bitcoinJVersion=1.0.4


### PR DESCRIPTION
Fixed accidental closure of listening key instead of client key when JCL refuses connection from a blacklisted peer, resulting in JCL not establishing incoming connections from any peers anymore (server mode).
Updated JCL version accordingly.