### PR TITLE
Self-advertisement on peer connect

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # JCL Variables:
 jclArtifactName=jcl
 jclGroup=io.bitcoinsv.jcl
-jclVersion=2.3.4
+jclVersion=2.3.5
 
 # BitcoinJ dependency:
 bitcoinJVersion=1.0.4

--- a/net/src/main/java/io/bitcoinsv/jcl/net/network/events/PeerConnectedEvent.java
+++ b/net/src/main/java/io/bitcoinsv/jcl/net/network/events/PeerConnectedEvent.java
@@ -5,7 +5,7 @@ import io.bitcoinsv.jcl.net.network.PeerAddress;
 
 /**
  * @author i.fernandez@nchain.com
- * Copyright (c) 2018-2020 nChain Ltd
+ * Copyright (c) 2018-2024 nChain Ltd
  *
  * An Event triggered when a Peer is Connected. This is a physical connection (Socket Connection),
  * so the real communication with this Peer has not even started yet. Most probably you will be interested in the
@@ -14,20 +14,26 @@ import io.bitcoinsv.jcl.net.network.PeerAddress;
  */
 public final class PeerConnectedEvent extends P2PEvent {
     private final PeerAddress peerAddress;
+    private final boolean isOutgoing;
 
-    public PeerConnectedEvent(PeerAddress peerAddress)  { this.peerAddress = peerAddress; }
+    public PeerConnectedEvent(PeerAddress peerAddress, boolean isOutgoing)  {
+        this.peerAddress = peerAddress;
+        this.isOutgoing = isOutgoing;
+    }
     public PeerAddress getPeerAddress()                 { return this.peerAddress; }
+    public boolean isOutgoingConnection()               { return this.isOutgoing; }
 
     @Override
     public String toString() {
-        return "Event[Peer Connected]: " + peerAddress.toString();
+        return String.format("Event[Peer Connected]: %s, %s connection",
+            peerAddress.toString(), (isOutgoing ? "outgoing" : "incoming"));
     }
 
     @Override
     public boolean equals(Object obj) {
         if (!super.equals(obj)) { return false; }
         PeerConnectedEvent other = (PeerConnectedEvent) obj;
-        return Objects.equal(this.peerAddress, other.peerAddress);
+        return Objects.equal(this.peerAddress, other.peerAddress) && this.isOutgoing == other.isOutgoing;
     }
 
     @Override

--- a/net/src/main/java/io/bitcoinsv/jcl/net/protocol/handlers/discovery/DiscoveryHandlerConfig.java
+++ b/net/src/main/java/io/bitcoinsv/jcl/net/protocol/handlers/discovery/DiscoveryHandlerConfig.java
@@ -1,10 +1,11 @@
 package io.bitcoinsv.jcl.net.protocol.handlers.discovery;
 
 
+import io.bitcoinsv.bitcoinjsv.params.NetworkParameters;
 import io.bitcoinsv.jcl.net.network.PeerAddress;
 import io.bitcoinsv.jcl.net.protocol.config.ProtocolBasicConfig;
+import io.bitcoinsv.jcl.net.protocol.config.ProtocolServices;
 import io.bitcoinsv.jcl.tools.handlers.HandlerConfig;
-import io.bitcoinsv.bitcoinjsv.params.NetworkParameters;
 
 import java.net.UnknownHostException;
 import java.time.Duration;
@@ -15,7 +16,7 @@ import java.util.OptionalInt;
 
 /**
  * @author i.fernandez@nchain.com
- * Copyright (c) 2018-2020 nChain Ltd
+ * Copyright (c) 2018-2024 nChain Ltd
  *
  * It stores the Configuration variables needed by the Discovery Handler.
  */
@@ -32,6 +33,7 @@ public class DiscoveryHandlerConfig extends HandlerConfig {
     public static final Optional<Duration> DEFAULT_HANDSHAKE_RECOVERY_THRESHOLD = Optional.of(Duration.ofMinutes(15));
     public static final Optional<Duration> DEFAULT_ADDR_BROADCAST_FREQ = Optional.of(Duration.ofDays(1)); //advertise itself every day by default
     public static final Optional<String> DEFAULT_ADVERTISED_IP = Optional.empty(); //no address to advertise by default - should be set manually
+    public static final Optional<Long> DEFAULT_ADVERTISED_SERVICES = Optional.of((long) ProtocolServices.NODE_BLOOM.getProtocolServices()); //NODE_BLOOM services as default, just like HandshakeHandlerConfig's default servicesSupported value
 
     // Node Discovery Configuration:
     public enum DiscoveryMethod {
@@ -63,6 +65,10 @@ public class DiscoveryHandlerConfig extends HandlerConfig {
      * Address to include in the periodic advertisement (ADDR message)
      */
     private Optional<String> advertisedIp = DEFAULT_ADVERTISED_IP;
+    /**
+     * Services to include in the periodic advertisement (ADDR message)
+     */
+    private Optional<Long> advertisedServices = DEFAULT_ADVERTISED_SERVICES;
     /** frequency of the job that reconnects to those peers that used to be handshaked but are now disconnected */
     private Optional<Duration> recoveryHandshakeFrequency = DEFAULT_HANDSHAKE_RECOVERY_FREQ;
     /**
@@ -88,7 +94,8 @@ public class DiscoveryHandlerConfig extends HandlerConfig {
                                   boolean checkingPeerReachability,
                                   List<PeerAddress> initialConnections,
                                   Optional<Duration> addrBroadcastFrequency,
-                                  Optional<String> advertisedIp) {
+                                  Optional<String> advertisedIp,
+                                  Optional<Long> advertisedServices) {
         this.basicConfig = basicConfig;
         this.dns = dns;
         if (discoveryMethod != null)            this.discoveryMethod = discoveryMethod;
@@ -101,6 +108,7 @@ public class DiscoveryHandlerConfig extends HandlerConfig {
         if (recoveryHandshakeThreshold != null) this.recoveryHandshakeThreshold = recoveryHandshakeThreshold;
         if (addrBroadcastFrequency != null)     this.addrBroadcastFrequency = addrBroadcastFrequency;
         if (advertisedIp != null)               this.advertisedIp = advertisedIp;
+        if (advertisedServices != null)         this.advertisedServices = advertisedServices;
         this.checkingPeerReachability = checkingPeerReachability;
         this.initialConnections = initialConnections;
     }
@@ -121,6 +129,7 @@ public class DiscoveryHandlerConfig extends HandlerConfig {
     public List<PeerAddress> getInitialConnections()            { return this.initialConnections;}
     public Optional<Duration> getAddrBroadcastFrequency()       { return this.addrBroadcastFrequency; }
     public Optional<String> getAdvertisedIp()                   { return this.advertisedIp; }
+    public Optional<Long> getAdvertisedServices()               { return this.advertisedServices; }
 
     public DiscoveryHandlerConfigBuilder toBuilder() {
         return new DiscoveryHandlerConfigBuilder().basicConfig(this.basicConfig)
@@ -136,7 +145,8 @@ public class DiscoveryHandlerConfig extends HandlerConfig {
                 .checkingPeerReachability(this.checkingPeerReachability)
                 .addInitialConnections(this.initialConnections)
                 .addrBroadcastFrequency(this.addrBroadcastFrequency)
-                .advertisedIp(this.advertisedIp);
+                .advertisedIp(this.advertisedIp)
+                .advertisedServices(this.advertisedServices);
     }
 
     public static DiscoveryHandlerConfigBuilder builder() {
@@ -161,6 +171,7 @@ public class DiscoveryHandlerConfig extends HandlerConfig {
         private List<PeerAddress> initialConnections = new ArrayList<>();
         private Optional<Duration> addrBroadcastFrequency;
         private Optional<String> advertisedIp;
+        private Optional<Long> advertisedServices;
 
         DiscoveryHandlerConfigBuilder() { }
 
@@ -253,6 +264,11 @@ public class DiscoveryHandlerConfig extends HandlerConfig {
             return this;
         }
 
+        public DiscoveryHandlerConfig.DiscoveryHandlerConfigBuilder advertisedServices(Optional<Long> advertisedServices){
+            this.advertisedServices = advertisedServices;
+            return this;
+        }
+
         public DiscoveryHandlerConfig build() {
             return new DiscoveryHandlerConfig(basicConfig,
                     dns,
@@ -267,7 +283,8 @@ public class DiscoveryHandlerConfig extends HandlerConfig {
                     checkingPeerReachability,
                     initialConnections,
                     addrBroadcastFrequency,
-                    advertisedIp);
+                    advertisedIp,
+                    advertisedServices);
         }
     }
 }

--- a/net/src/main/java/io/bitcoinsv/jcl/net/protocol/handlers/handshake/HandshakeHandlerImpl.java
+++ b/net/src/main/java/io/bitcoinsv/jcl/net/protocol/handlers/handshake/HandshakeHandlerImpl.java
@@ -26,9 +26,11 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
+import static java.time.Instant.now;
+
 /**
  * @author i.fernandez@nchain.com
- * Copyright (c) 2018-2020 nChain Ltd
+ * Copyright (c) 2018-2024 nChain Ltd
  */
 public class HandshakeHandlerImpl extends HandlerImpl<PeerAddress, HandshakePeerInfo> implements HandshakeHandler {
 
@@ -450,11 +452,11 @@ public class HandshakeHandlerImpl extends HandlerImpl<PeerAddress, HandshakePeer
         VarStrMsg userAgentMsg = VarStrMsg.builder().str( config.getUserAgent()).build();
         NetAddressMsg addr_from = NetAddressMsg.builder()
                 .address(localAddress)
-                .timestamp(System.currentTimeMillis())
+                .timestamp(now().getEpochSecond())
                 .build();
         NetAddressMsg addr_recv = NetAddressMsg.builder()
                 .address(peerInfo.getPeerAddress())
-                .timestamp(System.currentTimeMillis())
+                .timestamp(now().getEpochSecond())
                 .build();
         VersionMsg versionMsg = VersionMsg.builder()
                 .user_agent(userAgentMsg)
@@ -465,7 +467,7 @@ public class HandshakeHandlerImpl extends HandlerImpl<PeerAddress, HandshakePeer
                 .addr_recv(addr_recv)
                 .start_height(config.getBlock_height())
                 .nonce(NonceUtils.newOnce())
-                .timestamp(System.currentTimeMillis())
+                .timestamp(now().getEpochSecond())
                 .build();
         BitcoinMsg<VersionMsg> btcVersionMsg = new BitcoinMsgBuilder<VersionMsg>(config.getBasicConfig(), versionMsg).build();
         super.eventBus.publish(new SendMsgRequest(peerInfo.getPeerAddress(), btcVersionMsg));


### PR DESCRIPTION
NOC-830: Fixed timestamp when assembling a VERSION message to use epoch seconds instead of epoch milliseconds. Added self-advertisement on peer connect (if the connection is outgoing) & added advertised services field. Updated `PeerConnectedEvent` to include a flag for determining if a peer connection is incoming or outgoing. Bumped JCL version to 2.3.5.